### PR TITLE
TyCart pass

### DIFF
--- a/.github/workflows/basic-ci.yml
+++ b/.github/workflows/basic-ci.yml
@@ -1,0 +1,73 @@
+name: TyCart-CI
+
+on:
+  push:
+    branches: [ master, devel ]
+  pull_request:
+
+env:
+  CXX: clang++-10
+  CC: clang-10
+  EXTERNAL_LIT: /usr/lib/llvm-10/build/utils/lit/lit.py
+  OMP_NUM_THREAD: 2
+
+jobs:
+  format-check:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Format source code
+        run: |
+          find lib test \
+            -type f \
+            -name "*.c" -o -name "*.cpp" -o -name "*.h" \
+            -print0 \
+            | xargs -0 clang-format-10 -i
+
+      - name: List newly formatted files
+        run: git status --porcelain --untracked-files=no
+
+      - name: Check format
+        run: git status --porcelain --untracked-files=no | xargs -o -I {} test -z \"{}\"
+
+  lit-suite:
+    runs-on: ubuntu-20.04
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    strategy:
+      fail-fast: false
+      matrix:
+        preset:
+          - name: develop
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Update apt
+        run: sudo apt-get update
+
+      - name: Install LLVM
+        run: sudo apt-get install libllvm10 llvm-10 llvm-10-dev
+
+      - name: Install Clang
+        run: sudo apt-get install clang-10 clang-tidy-10
+
+      - name: Setup env
+        run: |
+          sudo ln -f -s /usr/bin/clang-10 /usr/bin/clang
+          sudo ln -f -s /usr/bin/clang++-10 /usr/bin/clang++
+          sudo ln -f -s /usr/bin/opt-10 /usr/bin/opt
+          sudo ln -f -s /usr/bin/FileCheck-10 /usr/bin/FileCheck
+          sudo ln -f -s /usr/bin/llc-10 /usr/bin/llc
+          sudo ln -f -s /usr/bin/clang-tidy-10 /usr/bin/clang-tidy
+
+      - name: Configure TyCart
+        run: cmake -B build --preset ${{ matrix.preset.name }} -DLLVM_EXTERNAL_LIT=${EXTERNAL_LIT}
+
+      - name: Build TyCart
+        run: cmake --build build --parallel 2
+
+      - name: Test TyCart lit-suite
+        if: matrix.preset.skip_test == false
+        run: cmake --build build --target lit-tycart-test

--- a/.github/workflows/basic-ci.yml
+++ b/.github/workflows/basic-ci.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Install Clang
         run: sudo apt-get install clang-10 clang-tidy-10
 
+      - name: Install OpenMPI
+        run: sudo apt-get install libopenmpi-dev openmpi-bin
+
       - name: Setup env
         run: |
           sudo ln -f -s /usr/bin/clang-10 /usr/bin/clang

--- a/lib/pass/CMakeLists.txt
+++ b/lib/pass/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(PASS_SOURCES
   TyCartPass.cpp
+  support/TypeUtil.cpp
+  support/TypeUtil.h
 )
 
 add_llvm_pass_plugin(tycart_TransformPass

--- a/lib/pass/TyCartPass.cpp
+++ b/lib/pass/TyCartPass.cpp
@@ -13,8 +13,9 @@
 #include "TyCartPass.h"
 
 #include "support/Log.h"
-#include "typegen/TypeGenerator.h"  // TypeART part
-#include "typelib/TypeInterface.h"  // TypeART part
+#include "support/TypeUtil.h"
+#include "typegen/TypeGenerator.h"
+#include "typelib/TypeInterface.h"
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/IR/DataLayout.h"
@@ -35,9 +36,215 @@ static cl::opt<std::string> cl_type_file("tycart-types", cl::desc("Location of t
 
 namespace tycart {
 
+namespace callback {
+
+struct FunctionDecl {
+  struct TyCartFunction {
+    const std::string name;
+    llvm::Function* f{nullptr};
+  };
+
+  TyCartFunction assert_tycart{"tycart_assert_"};
+  TyCartFunction assert_tycart_auto{"tycart_assert_auto_"};
+  TyCartFunction assert_tycart_fti_t{"tycart_register_FTI_t_"};
+
+  void initialize(Module& m) {
+    using namespace llvm;
+    auto& c = m.getContext();
+
+    const auto add_optimizer_attributes = [&](auto& arg) {
+      arg.addAttr(Attribute::NoCapture);
+      arg.addAttr(Attribute::ReadOnly);
+    };
+
+    const auto make_function = [&](auto& f_struct, auto f_type) {
+      auto func_callee = m.getOrInsertFunction(f_struct.name, f_type);
+      f_struct.f       = dyn_cast<Function>(func_callee.getCallee());
+      if (auto f = dyn_cast<Function>(f_struct.f)) {
+        f->setLinkage(GlobalValue::ExternalLinkage);
+        auto& first_param = *(f->arg_begin());
+        if (first_param.getType()->isPointerTy()) {
+          add_optimizer_attributes(first_param);
+        }
+      }
+    };
+
+    Type* assert_arg_types_tycart_auto[] = {Type::getInt32Ty(c), Type::getInt8PtrTy(c), Type::getInt64Ty(c),
+                                            Type::getInt32Ty(c)};
+    Type* assert_arg_types_tycart[]      = {Type::getInt32Ty(c), Type::getInt8PtrTy(c), Type::getInt64Ty(c),
+                                       Type::getInt64Ty(c), Type::getInt32Ty(c)};
+    Type* assert_arg_types_tycart_fti[]  = {Type::getInt32Ty(c)};
+
+    make_function(assert_tycart_auto, FunctionType::get(Type::getVoidTy(c), assert_arg_types_tycart_auto, false));
+    make_function(assert_tycart, FunctionType::get(Type::getVoidTy(c), assert_arg_types_tycart, false));
+    make_function(assert_tycart_fti_t, FunctionType::get(Type::getVoidTy(c), assert_arg_types_tycart_fti, false));
+  }
+};
+
+}  // namespace callback
+
+namespace analysis {
+enum class AssertKind { kTycart, kTycartFtiT, kTycartAuto };
+
+const llvm::StringMap<AssertKind> kAssertMap{{"tycart_assert_stub_", AssertKind::kTycart},
+                                             {"tycart_register_FTI_t_stub_", AssertKind::kTycartFtiT},
+                                             {"tycart_assert_auto_stub_", AssertKind::kTycartAuto}};
+
+struct AssertData {
+  // TODO  asserts have bitcasts on various args
+  llvm::CallBase* call{nullptr};
+  AssertKind kind;
+};
+
+using AssertDataVec = llvm::SmallVector<AssertData, 4>;
+
+class AssertOpVisitor : public llvm::InstVisitor<AssertOpVisitor> {
+  AssertDataVec asserts_;
+
+ public:
+  const AssertDataVec& getAsserts() {
+    return asserts_;
+  }
+
+  void clear() {
+    asserts_.clear();
+  }
+
+  void visitCallBase(llvm::CallBase& cb) {
+    if (auto* f = cb.getCalledFunction()) {
+      auto kind = getKind(f);
+      if (kind) {
+        asserts_.push_back(AssertData{&cb, kind.getValue()});
+      }
+    }
+  }
+
+ private:
+  static llvm::Optional<AssertKind> getKind(Function* f) {
+    const auto function = f->getName();
+    if (auto it = kAssertMap.find(function); it != std::end(kAssertMap)) {
+      return it->second;
+    }
+    return None;
+  }
+};
+
+}  // namespace analysis
+
+namespace transform {
+
+inline llvm::Error make_string_error(const char* message) {
+  return llvm::make_error<llvm::StringError>(llvm::inconvertibleErrorCode(), message);
+}
+
+struct TycartAssertArgs {
+  Value* buffer;
+  Value* length;
+  Value* checkpoint_id;
+  Value* type_size;
+  Value* typeart_type_id;
+  analysis::AssertData assert;
+};
+
+llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const TycartAssertArgs& args) {
+  os << "Buffer: " << *args.buffer << "| Length: " << *args.length << "| Check id: " << *args.checkpoint_id
+     << "| Size: " << *args.type_size << "| Type ID: " << *args.typeart_type_id;
+
+  return os;
+}
+
+class AssertStubCollector {
+  Function* f_;
+  DataLayout* dl_;
+  const typeart::TypeGenerator* type_gen_;
+
+ public:
+  AssertStubCollector(Function* f, DataLayout* dl, const typeart::TypeGenerator* type_gen)
+      : f_(f), dl_(dl), type_gen_(type_gen) {
+  }
+
+  Expected<TycartAssertArgs> handleTycart(const analysis::AssertData& ad) const {
+    auto* assert_stub = ad.call;
+
+    assert(assert_stub->arg_size() >= 4);
+
+    Value* arg_buffer        = assert_stub->getArgOperand(0);
+    Value* arg_type          = assert_stub->getArgOperand(1);
+    Value* arg_length        = assert_stub->getArgOperand(2);
+    Value* arg_checkpoint_id = assert_stub->getArgOperand(3);
+
+    if (!arg_buffer) {
+      return {make_string_error("Error buffer argument of assert stub is null.")};
+    }
+    if (!arg_type) {
+      return {make_string_error("Error type argument of assert stub is null.")};
+    }
+    if (!arg_length) {
+      return {make_string_error("Error length argument of assert stub is null.")};
+    }
+    if (!arg_checkpoint_id) {
+      return {make_string_error("Error checkpoint argument of assert stub is null.")};
+    }
+
+    auto* arg_type_ptr = arg_type->getType();
+    if (!arg_type_ptr->isPointerTy()) {
+      return {make_string_error("Error type argument must be a pointer type.")};
+    }
+
+    // TODO testing:
+    if (auto* arg_type_ptr_cast = dyn_cast<BitCastInst>(arg_type)) {
+      arg_type_ptr = arg_type_ptr_cast->getSrcTy();
+    }
+
+    auto* type           = arg_type_ptr->getPointerElementType();
+    auto type_size_bytes = util::getTypeSizeInBytes(type, *dl_);
+    auto* type_size      = ConstantInt::get(IntegerType::get(f_->getContext(), 64), type_size_bytes);
+
+    int typeart_type_id = type_gen_->getTypeID(type, *dl_);
+    if (typeart_type_id == TYPEART_UNKNOWN_TYPE) {
+      return {make_string_error("Error assert type is not supported/unknown.")};
+    }
+    auto* typeart_type = ConstantInt::get(IntegerType::get(f_->getContext(), 32), typeart_type_id);
+
+    return TycartAssertArgs{arg_buffer, arg_length, arg_checkpoint_id, type_size, typeart_type, ad};
+  }
+};
+
+class AssertStubTransformer {
+  Function* f_;
+  callback::FunctionDecl* decls_;
+
+ public:
+  AssertStubTransformer(Function* f, callback::FunctionDecl* decls) : f_(f), decls_(decls) {
+  }
+
+  [[nodiscard]] bool handleTycart(const TycartAssertArgs& ad) const {
+    using namespace llvm;
+    LOG_DEBUG(ad);
+
+    auto* call_inst      = ad.assert.call;
+    const bool is_invoke = llvm::isa<llvm::InvokeInst>(call_inst);
+
+    if (is_invoke) {
+    } else {
+      // normal callinst:
+      auto* target_callback = decls_->assert_tycart.f;
+      IRBuilder<> irb(call_inst->getNextNode());
+      irb.CreateCall(target_callback,
+                     ArrayRef<Value*>{ad.checkpoint_id, ad.buffer, ad.length, ad.type_size, ad.typeart_type_id});
+      call_inst->eraseFromParent();
+    }
+
+    return true;
+  }
+};
+
+}  // namespace transform
+
 class TyCartPass : public ModulePass {
  private:
   std::unique_ptr<typeart::TypeGenerator> typegen_;
+  callback::FunctionDecl tycart_decls_;
 
  public:
   static char ID;  // NOLINT
@@ -52,9 +259,9 @@ class TyCartPass : public ModulePass {
     if (!ret.first) {
       LOG_WARNING("Could not load type file: " << cl_type_file.getValue())
     }
+    tycart_decls_.initialize(m);
     return true;
   }
-
   bool doFinalization(Module&) override {
     if (typegen_) {
       const auto stored = typegen_->store();
@@ -72,6 +279,43 @@ class TyCartPass : public ModulePass {
       return false;
     }
     bool mod{false};
+    DataLayout dl(f.getParent());
+
+    analysis::AssertOpVisitor visitor;
+    visitor.visit(f);
+    const auto asserts = visitor.getAsserts();
+
+    if (asserts.empty()) {
+      return false;
+    }
+
+    transform::AssertStubCollector collector{&f, &dl, typegen_.get()};
+    transform::AssertStubTransformer transformer{&f, &tycart_decls_};
+
+    const auto process_type_assert = [&](const analysis::AssertData& ad) -> bool {
+      switch (ad.kind) {
+        case analysis::AssertKind::kTycart: {
+          auto data = collector.handleTycart(ad);
+          if (data) {
+            return transformer.handleTycart(data.get());
+          }
+          // TODO error handling
+          break;
+        }
+        case analysis::AssertKind::kTycartFtiT:
+          assert(("kTycartFtiT - Not yet supported", false));
+          break;
+        case analysis::AssertKind::kTycartAuto:
+          assert(("kTycartAuto - Not yet supported", false));
+          break;
+        default:
+          assert(("Missing case stmt in processTypeAssert", false));
+          break;
+      }
+      return false;
+    };
+
+    mod |= llvm::count_if(asserts, process_type_assert) > 0;
 
     return mod;
   }

--- a/lib/pass/TyCartPass.cpp
+++ b/lib/pass/TyCartPass.cpp
@@ -134,6 +134,8 @@ class AssertOpVisitor : public llvm::InstVisitor<AssertOpVisitor> {
 namespace transform {
 
 inline llvm::Error make_string_error(const char* message) {
+  // TODO replace llvm::inconvertibleErrorCode()
+
   return llvm::make_error<llvm::StringError>(llvm::inconvertibleErrorCode(), message);
 }
 
@@ -343,7 +345,7 @@ class TyCartPass : public ModulePass {
   static char ID;  // NOLINT
 
   TyCartPass() : ModulePass(ID) {
-    assert(("Default type file not set", !cl_type_file.empty()));
+    assert((!cl_type_file.empty() && "Default type file not set."));
   }
 
   bool doInitialization(Module& m) override {
@@ -392,7 +394,7 @@ class TyCartPass : public ModulePass {
           if (data) {
             return transformer.handleTycart(data.get());
           }
-          // TODO error handling
+          LOG_ERROR("Error with assert stub: " << *ad.call)
           break;
         }
         case analysis::AssertKind::kTycartFtiT: {
@@ -400,6 +402,7 @@ class TyCartPass : public ModulePass {
           if (data) {
             return transformer.handleTycartFTI(data.get());
           }
+          LOG_ERROR("Error with FTI register stub: " << *ad.call)
           break;
         }
         case analysis::AssertKind::kTycartAuto: {
@@ -407,10 +410,11 @@ class TyCartPass : public ModulePass {
           if (data) {
             return transformer.handleTycartAuto(data.get());
           }
+          LOG_ERROR("Error with assert auto stub: " << *ad.call)
           break;
         }
         default:
-          assert(("Missing case stmt in processTypeAssert", false));
+          llvm_unreachable("Missing case stmt in processTypeAssert");
           break;
       }
       return false;

--- a/lib/pass/support/TypeUtil.cpp
+++ b/lib/pass/support/TypeUtil.cpp
@@ -1,0 +1,125 @@
+// TyCart library
+//
+// Copyright (c) 2021-2021 TyCart Authors
+// Distributed under the BSD 3-Clause license.
+// (See accompanying file LICENSE or copy at
+// https://opensource.org/licenses/BSD-3-Clause)
+//
+// Project home: https://github.com/tudasc/TyCart
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copied and modified from the TypeART library
+
+#include "TypeUtil.h"
+
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Type.h"
+#include "llvm/IR/Value.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/TypeSize.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace llvm;
+
+namespace tycart::util {
+
+unsigned getScalarSizeInBytes(llvm::Type* t) {
+  return t->getScalarSizeInBits() / 8;
+}
+
+unsigned getVectorSizeInBytes(llvm::Type* vectorT, const llvm::DataLayout& dl) {
+  // TODO: Most of these utility functions can be eliminated with the use of getTypeAllocSize() and getTypeStoreSize()
+  //  auto vt = dyn_cast<VectorType>(vectorT);
+  return dl.getTypeAllocSize(vectorT);
+  // return getTypeSizeInBytes(vt->getVectorElementType(), dl) * vt->getVectorNumElements();
+}
+
+/**
+ * \brief Resolves the element type of the given array recursively. Works for multidimensional arrays.
+ */
+llvm::Type* getArrayElementType(llvm::Type* arrT) {
+  while (arrT->isArrayTy()) {
+    arrT = arrT->getArrayElementType();
+  }
+  return arrT;
+}
+
+/**
+ * \brief Determines the length of the flattened array.
+ *  TODO: Handle VLAs
+ */
+unsigned getArrayLengthFlattened(llvm::Type* arrT) {
+  unsigned len = 1;
+  while (arrT->isArrayTy()) {
+    len *= arrT->getArrayNumElements();
+    arrT = arrT->getArrayElementType();
+  }
+  return len;
+}
+
+unsigned getStructSizeInBytes(llvm::Type* structT, const llvm::DataLayout& dl) {
+  auto st                    = dyn_cast<llvm::StructType>(structT);
+  const StructLayout* layout = dl.getStructLayout(st);
+  return layout->getSizeInBytes();
+}
+
+unsigned getPointerSizeInBytes(llvm::Type* /*ptrT*/, const llvm::DataLayout& dl) {
+  return dl.getPointerSizeInBits() / 8;
+}
+
+unsigned getTypeSizeForArrayAlloc(llvm::AllocaInst* ai, const llvm::DataLayout& dl) {
+  // TODO: Not used at the moment. Integrate VLA check into replacement methods (getArrayLengthFlattened).
+
+  auto type = ai->getAllocatedType();
+  unsigned bytes;
+  if (type->isArrayTy()) {
+    bytes = getTypeSizeInBytes(type->getArrayElementType(), dl);
+  } else {
+    bytes = getTypeSizeInBytes(type, dl);
+  }
+  if (ai->isArrayAllocation()) {
+    if (auto ci = dyn_cast<ConstantInt>(ai->getArraySize())) {
+      bytes *= ci->getLimitedValue();
+    } else {
+      // If this can not be determined statically, we have to compute it at
+      // runtime. We insert additional instructions to calculate the
+      // numBytes of that array on the fly. (VLAs produce this kind of
+      // behavior)
+      // ATTENTION: We can have multiple such arrays in a single BB. We need
+      // to have a small vector to store whether we already generated
+      // instructions, to possibly refer to the results for further
+      // calculations.
+
+      // TODO LOG_WARNING("We hit not yet determinable array size expression: " << *ai);
+    }
+  }
+  return bytes;
+}
+unsigned getArraySizeInBytes(llvm::Type* arrT, const llvm::DataLayout& dl);
+
+unsigned getTypeSizeInBytes(llvm::Type* t, const llvm::DataLayout& dl) {
+  unsigned bytes = getScalarSizeInBytes(t);
+
+  if (t->isArrayTy()) {
+    bytes = getArraySizeInBytes(t, dl);
+  } else if (t->isStructTy()) {
+    bytes = getStructSizeInBytes(t, dl);
+  } else if (t->isPointerTy()) {
+    bytes = getPointerSizeInBytes(t, dl);
+  } else if (t->isVectorTy()) {
+    bytes = getVectorSizeInBytes(t, dl);
+  }
+
+  return bytes;
+}
+
+unsigned getArraySizeInBytes(llvm::Type* arrT, const llvm::DataLayout& dl) {
+  auto st = dyn_cast<ArrayType>(arrT);
+  return getTypeSizeInBytes(getArrayElementType(st), dl) * getArrayLengthFlattened(st);
+}
+
+}  // namespace tycart::util

--- a/lib/pass/support/TypeUtil.h
+++ b/lib/pass/support/TypeUtil.h
@@ -1,0 +1,27 @@
+// TyCart library
+//
+// Copyright (c) 2021-2021 TyCart Authors
+// Distributed under the BSD 3-Clause license.
+// (See accompanying file LICENSE or copy at
+// https://opensource.org/licenses/BSD-3-Clause)
+//
+// Project home: https://github.com/tudasc/TyCart
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#ifndef TYCART_SUPPORT_TYPE_UTIL_H
+#define TYCART_SUPPORT_TYPE_UTIL_H
+
+namespace llvm {
+class DataLayout;
+class Type;
+}  // namespace llvm
+
+namespace tycart::util {
+
+unsigned getTypeSizeInBytes(llvm::Type* t, const llvm::DataLayout& dl);
+
+}  // namespace tycart::util
+
+#endif  // TYCART_SUPPORT_TYPE_UTIL_H

--- a/lib/runtime/TycartAssert.h
+++ b/lib/runtime/TycartAssert.h
@@ -24,6 +24,8 @@ extern "C" {
 #endif  // __cplusplus
 
 void tycart_assert_stub_(const void* pointer, void* tycart_stub_ptr, size_t count, int checkpoint_id);
+void tycart_assert_auto_stub_(const void* pointer, void* tycart_stub_ptr, int checkpoint_id);
+void tycart_register_FTI_t_stub_(const void* ptr);
 
 #ifdef __cplusplus
 }

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -53,4 +53,3 @@ config.substitutions.append(('%cpp-to-llvm', 'clang++ {}'.format(to_llvm_args)))
 
 #config.substitutions.append(('%apply-typeart-tycart', 'opt -load {} -load {} {} | opt -load {} {}'.format(typeart_analysis_pass, typeart_transform_pass,typeart_std_args, transform_pass, std_plugin_args)))
 config.substitutions.append(('%apply-typeart', 'opt -load {} -load {} {}'.format(typeart_analysis_pass, typeart_transform_pass, typeart_std_args)))
-q

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -21,10 +21,14 @@ config.test_format = lit.formats.ShTest(execute_external=True)
 config.suffixes = ['.c','.cpp']
 config.excludes = ['Inputs']
 
-tycart_base_lib_dir= getattr(config, 'tycart_base_lib_dir', None)
+tycart_base_lib_dir = getattr(config, 'tycart_base_lib_dir', None)
 tycart_pass_root    = getattr(config, 'tycart_pass_dir', None)
-tycart_rt_root     = getattr(config, 'tycart_rt_dir', None)
+tycart_rt_root      = getattr(config, 'tycart_rt_dir', None)
 transform_name      = getattr(config, 'tycart_pass', None)
+
+typeart_transform_pass = getattr(config, 'typeart_pass', None)
+typeart_analysis_pass  = getattr(config, 'typeart_analysis_pass', None)
+typeart_std_args       = '-typeart'
 
 transform_pass      = '{}/{}'.format(tycart_pass_root, transform_name)
 std_plugin_args     = '-tycart'
@@ -46,3 +50,6 @@ config.substitutions.append(('%arg_std', std_plugin_args))
 config.substitutions.append(('%apply-tycart', 'opt -load {} {}'.format(transform_pass, std_plugin_args)))
 config.substitutions.append(('%c-to-llvm', 'clang {}'.format(to_llvm_args)))
 config.substitutions.append(('%cpp-to-llvm', 'clang++ {}'.format(to_llvm_args)))
+
+#config.substitutions.append(('%apply-typeart-tycart', 'opt -load {} -load {} {} | opt -load {} {}'.format(typeart_analysis_pass, typeart_transform_pass,typeart_std_args, transform_pass, std_plugin_args)))
+config.substitutions.append(('%apply-typeart', 'opt -load {} -load {} {}'.format(typeart_analysis_pass, typeart_transform_pass, typeart_std_args)))

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -53,3 +53,4 @@ config.substitutions.append(('%cpp-to-llvm', 'clang++ {}'.format(to_llvm_args)))
 
 #config.substitutions.append(('%apply-typeart-tycart', 'opt -load {} -load {} {} | opt -load {} {}'.format(typeart_analysis_pass, typeart_transform_pass,typeart_std_args, transform_pass, std_plugin_args)))
 config.substitutions.append(('%apply-typeart', 'opt -load {} -load {} {}'.format(typeart_analysis_pass, typeart_transform_pass, typeart_std_args)))
+q

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -10,6 +10,9 @@ import sys
 # config.typeart_pass = "$<TARGET_FILE_NAME:typeart::TransformPass>"
 # config.typeart_analysis_pass = "$<TARGET_FILE_NAME:typeart::MemOpFinderPass>"
 
+config.typeart_pass = "$<TARGET_FILE:typeart::TransformPass>"
+config.typeart_analysis_pass = "$<TARGET_FILE:typeart::MemOpFinderPass>"
+
 config.tycart_base_lib_dir = "@TYCART_BASE_LIBRARY_DIR@"
 config.tycart_pass_dir = "@TYCART_PASS_DIR@"
 config.tycart_rt_dir = "@TYCART_RT_DIR@"

--- a/test/pass/01_tycart_assert.c
+++ b/test/pass/01_tycart_assert.c
@@ -9,3 +9,4 @@ void foo(const void* data) {
 }
 
 // CHECK-NOT: Error
+// CHECK: tycart_assert_(i32 22, i8* %{{[0-9]+}}, i64 1, i64 8, i32 6)

--- a/test/pass/02_tycart_assert_inv.cpp
+++ b/test/pass/02_tycart_assert_inv.cpp
@@ -1,0 +1,15 @@
+// RUN: echo --- > types.yaml
+// RUN: %c-to-llvm %s | %apply-tycart -S | FileCheck %s
+
+#include "TycartUtil.h"
+
+void foo(const void* data) {
+  try {
+    double* typeart_type_id_placeholder = NULL;
+    tycart_assert_stub_(data, typeart_type_id_placeholder, 1, 22);
+  } catch (...) {
+  }
+}
+
+// CHECK-NOT: Error
+// CHECK: invoke void @tycart_assert_(i32 22, i8* %{{[0-9]+}}, i64 1, i64 8, i32 6)

--- a/test/pass/03_tycart_auto_assert.c
+++ b/test/pass/03_tycart_auto_assert.c
@@ -5,8 +5,8 @@
 
 void foo(const void* data) {
   double* typeart_type_id_placeholder = NULL;
-  tycart_assert_stub_(data, typeart_type_id_placeholder, 1, 22);
+  tycart_assert_auto_stub_(data, typeart_type_id_placeholder, 22);
 }
 
 // CHECK-NOT: Error
-// CHECK: tycart_assert_(i32 22, i8* %{{[0-9]+}}, i64 1, i64 8, i32 6)
+// CHECK: tycart_assert_auto_(i32 22, i8* %{{[0-9]+}}, i64 8, i32 6)

--- a/test/pass/04_tycart_auto_assert_inv.cpp
+++ b/test/pass/04_tycart_auto_assert_inv.cpp
@@ -6,10 +6,10 @@
 void foo(const void* data) {
   try {
     double* typeart_type_id_placeholder = nullptr;
-    tycart_assert_stub_(data, typeart_type_id_placeholder, 1, 22);
+    tycart_assert_auto_stub_(data, typeart_type_id_placeholder, 22);
   } catch (...) {
   }
 }
 
 // CHECK-NOT: Error
-// CHECK: invoke void @tycart_assert_(i32 22, i8* %{{[0-9]+}}, i64 1, i64 8, i32 6)
+// CHECK: invoke void @tycart_assert_auto_(i32 22, i8* %{{[0-9]+}}, i64 8, i32 6)

--- a/test/pass/05_tycart_fti.c
+++ b/test/pass/05_tycart_fti.c
@@ -5,8 +5,8 @@
 
 void foo(const void* data) {
   double* typeart_type_id_placeholder = NULL;
-  tycart_assert_stub_(data, typeart_type_id_placeholder, 1, 22);
+  tycart_register_FTI_t_stub_(typeart_type_id_placeholder);
 }
 
 // CHECK-NOT: Error
-// CHECK: tycart_assert_(i32 22, i8* %{{[0-9]+}}, i64 1, i64 8, i32 6)
+// CHECK: tycart_register_FTI_t_(i32 6)

--- a/test/pass/06_tycart_fti_inv.cpp
+++ b/test/pass/06_tycart_fti_inv.cpp
@@ -6,10 +6,10 @@
 void foo(const void* data) {
   try {
     double* typeart_type_id_placeholder = nullptr;
-    tycart_assert_stub_(data, typeart_type_id_placeholder, 1, 22);
+    tycart_register_FTI_t_stub_(typeart_type_id_placeholder);
   } catch (...) {
   }
 }
 
 // CHECK-NOT: Error
-// CHECK: invoke void @tycart_assert_(i32 22, i8* %{{[0-9]+}}, i64 1, i64 8, i32 6)
+// CHECK: invoke void @tycart_register_FTI_t_(i32 6)

--- a/test/pass/07_typeart_tycart_assert.c
+++ b/test/pass/07_typeart_tycart_assert.c
@@ -1,0 +1,24 @@
+// RUN: rm types.yaml
+// RUN: %c-to-llvm %s | %apply-typeart | %apply-tycart -S | FileCheck %s
+
+#include "TycartUtil.h"
+
+#include <stdlib.h>
+
+struct DataStruct {
+  double d;
+  float f;
+};
+
+struct DataStruct* bar() {
+  struct DataStruct* data = (struct DataStruct*)malloc(sizeof(struct DataStruct));
+  return data;
+}
+
+void foo(const void* data) {
+  struct DataStruct* typeart_type_id_placeholder = NULL;
+  tycart_assert_stub_(data, typeart_type_id_placeholder, 1, 22);
+}
+
+// CHECK-NOT: Error
+// CHECK: tycart_assert_(i32 22, i8* %{{[0-9]+}}, i64 1, i64 16, i32 256)

--- a/test/pass/08_typeart_tycart_assert_inv.cpp
+++ b/test/pass/08_typeart_tycart_assert_inv.cpp
@@ -1,0 +1,25 @@
+// RUN: rm types.yaml
+// RUN: %cpp-to-llvm %s | %apply-typeart | %apply-tycart -S | FileCheck %s
+
+#include "TycartUtil.h"
+
+struct DataStruct {
+  double d;
+  float f;
+};
+
+struct DataStruct* bar() {
+  DataStruct* data = new DataStruct;
+  return data;
+}
+
+void foo(const void* data) {
+  try {
+    DataStruct* typeart_type_id_placeholder = nullptr;
+    tycart_assert_stub_(data, typeart_type_id_placeholder, 1, 22);
+  } catch (...) {
+  }
+}
+
+// CHECK-NOT: Error
+// CHECK: invoke void @tycart_assert_(i32 22, i8* %{{[0-9]+}}, i64 1, i64 16, i32 256)


### PR DESCRIPTION
Initial LLVM pass implementation, supports the following stubs:

```c
void tycart_assert_stub_(const void* pointer, void* tycart_stub_ptr, size_t count, int checkpoint_id);
void tycart_assert_auto_stub_(const void* pointer, void* tycart_stub_ptr, int checkpoint_id);
void tycart_register_FTI_t_stub_(const void* ptr);
```