### PR TITLE
Register type

### DIFF
--- a/lib/pass/TyCartPass.cpp
+++ b/lib/pass/TyCartPass.cpp
@@ -12,10 +12,10 @@
 
 #include "TyCartPass.h"
 
+#include "TypeDatabase.h"
+#include "TypeGenerator.h"
+#include "TypeInterface.h"
 #include "support/Log.h"
-#include "typegen/TypeGenerator.h"
-#include "typelib/TypeDatabase.h"
-#include "typelib/TypeInterface.h"
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/IR/DataLayout.h"
@@ -166,10 +166,10 @@ llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const TycartAssertArgs& arg
 class AssertStubCollector {
   Function* f_;
   DataLayout* dl_;
-  const typeart::TypeGenerator* type_gen_;
+  typeart::TypeGenerator* type_gen_;
 
  public:
-  AssertStubCollector(Function* f, DataLayout* dl, const typeart::TypeGenerator* type_gen)
+  AssertStubCollector(Function* f, DataLayout* dl, typeart::TypeGenerator* type_gen)
       : f_(f), dl_(dl), type_gen_(type_gen) {
   }
 
@@ -273,7 +273,7 @@ class AssertStubCollector {
     }
 
     auto* type                = arg_type_ptr->getPointerElementType();
-    const int typeart_type_id = type_gen_->getTypeID(type, *dl_);
+    const int typeart_type_id = type_gen_->getOrRegisterType(type, *dl_);
     if (typeart_type_id == TYPEART_UNKNOWN_TYPE) {
       return {make_string_error("Error assert type is not supported/unknown.")};
     }

--- a/test/pass/07_typeart_tycart_assert.c
+++ b/test/pass/07_typeart_tycart_assert.c
@@ -1,5 +1,6 @@
 // RUN: rm types.yaml
 // RUN: %c-to-llvm %s | %apply-typeart | %apply-tycart -S | FileCheck %s
+// RUN: %c-to-llvm %s | %apply-tycart -S | FileCheck %s
 
 #include "TycartUtil.h"
 

--- a/test/pass/08_typeart_tycart_assert_inv.cpp
+++ b/test/pass/08_typeart_tycart_assert_inv.cpp
@@ -1,5 +1,6 @@
 // RUN: rm types.yaml
 // RUN: %cpp-to-llvm %s | %apply-typeart | %apply-tycart -S | FileCheck %s
+// RUN: %cpp-to-llvm %s | %apply-tycart -S | FileCheck %s
 
 #include "TycartUtil.h"
 


### PR DESCRIPTION
Change API to register a TyCart target type, in case of TypeART not yet encountering it.